### PR TITLE
Improve HTTP compliance of buildpack start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ A buildpack that does nothing other than wait a configurable amount of time whil
 
 Set the `SLEEPY_TIME` environment variable in your manifest to the number of seconds you want the staging process to sleep.
 
-Note: app files pushed using this buildpack are not served. It only serves the text 'OK' via Netcat.
+Note: app files pushed using this buildpack are not served.
+
+Apps with this buildpack as their only or final buildpack serve the text 'OK' on a path of `/`. All other paths serve a 404.
 
 ## Example usage
 
 ```bash
-git clone https://github.com/henrytk/cf-sleepy-buildpack.git
+git clone https://github.com/alphagov/paas-cf-sleepy-buildpack.git
 cd cf-sleepy-buildpack/app/
 cf push
 ```

--- a/app/manifest.yml
+++ b/app/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
  - name: sleepy-app
-   buildpack: https://github.com/henrytk/cf-sleepy-buildpack
+   buildpack: https://github.com/alphagov/paas-cf-sleepy-buildpack
    env:
      SLEEPY_TIME: 60

--- a/bin/release
+++ b/bin/release
@@ -3,5 +3,5 @@
 cat <<EOF
 ---
 default_process_types:
-  web: while true; do echo -en "HTTP/1.1 200 OK\n\nOK" | nc -l 8080; done
+  web: mkdir empty-dir && cd empty-dir && echo OK >index.html && python -m SimpleHTTPServer 8080
 EOF


### PR DESCRIPTION
# What
Something during the cf6 to cf7 upgrade started being unable to use this
buildpack's start command's output as HTTP content. We move to a less DIY start
command which works acceptably.

# How to review
Code review

# Who can review
Paired on by @jpluscplusm and @AP-Hunt 